### PR TITLE
Update mimemagic

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -114,7 +114,7 @@ GEM
     marcel (0.3.3)
       mimemagic (~> 0.3.2)
     method_source (1.0.0)
-    mimemagic (0.3.5)
+    mimemagic (0.3.6)
     mini_mime (1.0.2)
     mini_portile2 (2.5.0)
     minitest (5.14.4)


### PR DESCRIPTION
O autor da gem mimemagic apagou todas as versões antigas então nossos builds estão quebrando. Vocês podem achar mais detalhes [aqui](https://github.com/rails/rails/issues/41750)